### PR TITLE
Ensures the datepicker does not go off the right side of the screen.

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -146,6 +146,10 @@
             var offset = this.$trigger.offset(),
                 height = this.$trigger.outerHeight();
 
+            if (offset.left + this.$picker.outerWidth() > $(window).width()) {
+              offset.left = ($(window).width() - this.$picker.outerWidth())
+            }
+
             this.$picker.css({
                 top: offset.top + height,
                 left: offset.left


### PR DESCRIPTION
This commit aims to ensure that the datepicker dropdown does not place itself off the edge of the window by attempting to calculate if the offset + width is greater than the window width; if it is, it subtracts the overlap from the offset.