### PR TITLE
Added multi month feature

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -984,19 +984,15 @@
       if (data) {
         for (var picker in data) {
           if (data.hasOwnProperty(picker)) {
-            data[picker].setInactive();
+            data[picker].setActive(false);
           }
         }
       }
-      this.setActive();
+      this.setActive(true);
     },
 
-    setInactive: function () {
-      this._active = false;
-    },
-
-    setActive: function () {
-      this._active = true;
+    setActive: function (bool) {
+      this._active = bool;
     },
 
     isActive: function () {


### PR DESCRIPTION
With this change, multiple months can be added as follows.

```
$(".selector").datepicker({
      container: ".container",
      inline: true,
      days: {
          disablePrevious: true, 
          disableNext: true
      },
      months: {
          disableNavigation: true,
          number: 12
      }
  });
```
- **months.number** - number of months to show.
- **months.disableNavigation** - will disable prev/ next navigation links (i.e. month prev/ month current/ month next views)
- **days.disablePrevious** - will disable (i.e. not clickable) days of previous month in the current month window. 
- **days.disableNext** - will disable (i.e. not clickable) days of next month in the current month window.
