### PR TITLE
Update datepicker.js

### DIFF
--- a/dist/datepicker.js
+++ b/dist/datepicker.js
@@ -873,7 +873,7 @@
           } else {
             this.hideView();
           }
-
+          this.pick('year');
           break;
 
         case 'year':
@@ -912,7 +912,7 @@
           } else {
             this.hideView();
           }
-
+          this.pick('month');
           break;
 
         case 'month':


### PR DESCRIPTION
fix a bug.  current month and current year  don't set value to element after pick event.