### PR TITLE
Add Swedish (sv-SE) language

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -106,6 +106,7 @@
               <option value="fr-FR">fr-FR</option>
               <option value="nl-NL">nl-NL</option>
               <option value="pt-BR">pt-BR</option>
+              <option value="sv-SE">sv-SE</option>
               <option value="tr-TR">tr-TR</option>
               <option value="zh-CN">zh-CN</option>
             </select>
@@ -280,6 +281,7 @@
   <script src="js/datepicker.fr-FR.js"></script>
   <script src="js/datepicker.nl-NL.js"></script>
   <script src="js/datepicker.pt-BR.js"></script>
+  <script src="js/datepicker.sv-SE.js"></script>
   <script src="js/datepicker.tr-TR.js"></script>
   <script src="js/datepicker.zh-CN.js"></script>
   <script src="js/main.js"></script>

--- a/docs/js/datepicker.sv-SE.js
+++ b/docs/js/datepicker.sv-SE.js
@@ -1,0 +1,25 @@
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as anonymous module.
+    define('datepicker.sv-SE', ['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    // Node / CommonJS
+    factory(require('jquery'));
+  } else {
+    // Browser globals.
+    factory(jQuery);
+  }
+})(function ($) {
+
+  'use strict';
+
+  $.fn.datepicker.languages['sv-SE'] = {
+    format: 'yyyy-mm-dd',
+    days: ['Söndag', 'Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lördag'],
+    daysShort: ['Sön', 'Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör'],
+    daysMin: ['Sö', 'Må', 'Ti', 'On', 'To', 'Fr', 'Lö'],
+    weekStart: 1,
+    months: ['Januari', 'Februari', 'Mars', 'April', 'Maj', 'Juni', 'Juli', 'Augusti', 'September', 'Oktober', 'November', 'December'],
+    monthsShort: ['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec']
+  };
+});

--- a/i18n/datepicker.sv-SE.js
+++ b/i18n/datepicker.sv-SE.js
@@ -1,0 +1,25 @@
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as anonymous module.
+    define('datepicker.sv-SE', ['jquery'], factory);
+  } else if (typeof exports === 'object') {
+    // Node / CommonJS
+    factory(require('jquery'));
+  } else {
+    // Browser globals.
+    factory(jQuery);
+  }
+})(function ($) {
+
+  'use strict';
+
+  $.fn.datepicker.languages['sv-SE'] = {
+    format: 'yyyy-mm-dd',
+    days: ['Söndag', 'Måndag', 'Tisdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lördag'],
+    daysShort: ['Sön', 'Mån', 'Tis', 'Ons', 'Tor', 'Fre', 'Lör'],
+    daysMin: ['Sö', 'Må', 'Ti', 'On', 'To', 'Fr', 'Lö'],
+    weekStart: 1,
+    months: ['Januari', 'Februari', 'Mars', 'April', 'Maj', 'Juni', 'Juli', 'Augusti', 'September', 'Oktober', 'November', 'December'],
+    monthsShort: ['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec']
+  };
+});


### PR DESCRIPTION
Add Swedish language and format to Datepicker.
Includes `docs` version.