### PR TITLE
Fixed issue where if selected day is not in the current year it would not become 'picked'

### DIFF
--- a/dist/datepicker.common.js
+++ b/dist/datepicker.common.js
@@ -5,7 +5,7 @@
  * Copyright 2014-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2018-12-15T03:52:10.525Z
+ * Date: 2018-12-19T16:18:01.347Z
  */
 
 'use strict';
@@ -706,8 +706,10 @@ var handlers = {
         }
 
         viewDay = parseInt($target.text(), 10);
+        date.setYear(viewYear);
         date.setMonth(viewMonth);
         date.setDate(viewDay);
+        viewDate.setYear(viewYear);
         viewDate.setMonth(viewMonth);
         viewDate.setDate(viewDay);
         this.renderDays();

--- a/dist/datepicker.esm.js
+++ b/dist/datepicker.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2014-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2018-12-15T03:52:10.525Z
+ * Date: 2018-12-19T16:18:01.347Z
  */
 
 import $ from 'jquery';
@@ -702,8 +702,10 @@ var handlers = {
         }
 
         viewDay = parseInt($target.text(), 10);
+        date.setYear(viewYear);
         date.setMonth(viewMonth);
         date.setDate(viewDay);
+        viewDate.setYear(viewYear);
         viewDate.setMonth(viewMonth);
         viewDate.setDate(viewDay);
         this.renderDays();

--- a/dist/datepicker.js
+++ b/dist/datepicker.js
@@ -5,7 +5,7 @@
  * Copyright 2014-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2018-12-15T03:52:10.525Z
+ * Date: 2018-12-19T16:18:01.347Z
  */
 
 (function (global, factory) {
@@ -708,8 +708,10 @@
           }
 
           viewDay = parseInt($target.text(), 10);
+          date.setYear(viewYear);
           date.setMonth(viewMonth);
           date.setDate(viewDay);
+          viewDate.setYear(viewYear);
           viewDate.setMonth(viewMonth);
           viewDate.setDate(viewDay);
           this.renderDays();

--- a/docs/js/datepicker.js
+++ b/docs/js/datepicker.js
@@ -5,7 +5,7 @@
  * Copyright 2014-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2018-12-15T03:52:10.525Z
+ * Date: 2018-12-19T16:18:01.347Z
  */
 
 (function (global, factory) {
@@ -708,8 +708,10 @@
           }
 
           viewDay = parseInt($target.text(), 10);
+          date.setYear(viewYear);
           date.setMonth(viewMonth);
           date.setDate(viewDay);
+          viewDate.setYear(viewYear);
           viewDate.setMonth(viewMonth);
           viewDate.setDate(viewDay);
           this.renderDays();

--- a/src/js/handlers.js
+++ b/src/js/handlers.js
@@ -150,8 +150,10 @@ export default {
         }
 
         viewDay = parseInt($target.text(), 10);
+        date.setYear(viewYear);
         date.setMonth(viewMonth);
         date.setDate(viewDay);
+        viewDate.setYear(viewYear);
         viewDate.setMonth(viewMonth);
         viewDate.setDate(viewDay);
         this.renderDays();


### PR DESCRIPTION
When selecting a day that is not in the current year the `renderDays` method would not register it as picked. As a result the day element would not be given a `picked` value in the `data-view` attribute. The `pick.datedatepicker` callback is unaffected.